### PR TITLE
Another layer of protection for null in validator

### DIFF
--- a/DataSource.py
+++ b/DataSource.py
@@ -126,6 +126,10 @@ class DataSource:
     def add_keywords_to_article(self, id, keyword_string):
         self.cursor.execute("UPDATE articles SET keywords = %s WHERE id = %s", (keyword_string, id))
 
+    def article_processed(self, article_id):
+        self.cursor.execute("SELECT keywords FROM articles WHERE id = %s;", (article_id, ))
+        return self.cursor.fetchone()[0] is not None
+
 
 #def main():
 #    pass

--- a/ValidatorDaemon.py
+++ b/ValidatorDaemon.py
@@ -20,10 +20,11 @@ class ValidatorDaemon:
         for pair in unprocessed_pairs:
             query_id = pair[0]
             article_id = pair[1]
-            matching_prob = KeywordValidator().validate(query_id, article_id)
-            ds.post_validator_update(matching_prob, query_id, article_id)
-            if matching_prob > 0.2:
-                notifier.on_validation(query_id, article_id)
+            if ds.article_processed(article_id):
+                matching_prob = KeywordValidator().validate(query_id, article_id)
+                ds.post_validator_update(matching_prob, query_id, article_id)
+                if matching_prob > 0.2:
+                    notifier.on_validation(query_id, article_id)
 
 if __name__ == "__main__":
     ValidatorDaemon().run()


### PR DESCRIPTION
We were previously making the assumption that when the article reaches the validator, it has already been processed and has keywords, otherwise the JSON parser throws an error.
Now, before sending an article to the validator, check to see if keywords are null
NOTE: they should be stored as `'{}'` by json.parse if there are no keywords, so this will only block it if we have not yet tried to find keywords
